### PR TITLE
Todo model refactor 19

### DIFF
--- a/src/TodoList/Data.elm
+++ b/src/TodoList/Data.elm
@@ -4,7 +4,6 @@ module TodoList.Data exposing (Todo, compare)
 type alias Todo =
     { label : String
     , isCompleted : Bool
-    , id : Int
     }
 
 

--- a/src/TodoList/Decode.elm
+++ b/src/TodoList/Decode.elm
@@ -1,20 +1,23 @@
 module TodoList.Decode exposing (decode)
 
 import TodoList.Data exposing (Todo)
-import Json.Decode exposing (Decoder, Value, decodeString, decodeValue, list, string, bool, int)
+import Json.Decode exposing (Decoder, Value, decodeString, decodeValue, dict, string, bool, int)
 import Json.Decode.Pipeline as Pipeline exposing (required)
+import Dict exposing (Dict)
+import Utils
 
 
-decode : Value -> Result String (List Todo)
+decode : Value -> Result String (Dict Int Todo)
 decode value =
     value
         |> decodeValue string
         |> Result.andThen fromJson
+        |> Result.andThen (Utils.mapKeysOrFail String.toInt)
 
 
-fromJson : String -> Result String (List Todo)
+fromJson : String -> Result String (Dict String Todo)
 fromJson =
-    decodeString (list todoDecoder)
+    decodeString (dict todoDecoder)
 
 
 todoDecoder : Decoder Todo
@@ -22,4 +25,3 @@ todoDecoder =
     Pipeline.decode Todo
         |> required "label" string
         |> required "isCompleted" bool
-        |> required "id" int

--- a/src/TodoList/Decode.elm
+++ b/src/TodoList/Decode.elm
@@ -1,10 +1,9 @@
 module TodoList.Decode exposing (decode)
 
 import TodoList.Data exposing (Todo)
-import Json.Decode exposing (Decoder, Value, decodeString, decodeValue, dict, string, bool, int)
+import Json.Decode exposing (Decoder, Value, decodeString, decodeValue, list, string, bool, int, at, map2)
 import Json.Decode.Pipeline as Pipeline exposing (required)
 import Dict exposing (Dict)
-import Utils
 
 
 decode : Value -> Result String (Dict Int Todo)
@@ -12,16 +11,23 @@ decode value =
     value
         |> decodeValue string
         |> Result.andThen fromJson
-        |> Result.andThen (Utils.mapKeysOrFail String.toInt)
+        |> Result.map Dict.fromList
 
 
-fromJson : String -> Result String (Dict String Todo)
+fromJson : String -> Result String (List ( Int, Todo ))
 fromJson =
-    decodeString (dict todoDecoder)
+    decodeString (list todoRow)
 
 
-todoDecoder : Decoder Todo
-todoDecoder =
+todo : Decoder Todo
+todo =
     Pipeline.decode Todo
         |> required "label" string
         |> required "isCompleted" bool
+
+
+todoRow : Decoder ( Int, Todo )
+todoRow =
+    Pipeline.decode (,)
+        |> required "0" int
+        |> required "1" todo

--- a/src/TodoList/Encode.elm
+++ b/src/TodoList/Encode.elm
@@ -5,11 +5,11 @@ import Json.Encode exposing (Value, object, list, string, bool, int)
 import Dict exposing (Dict)
 
 
-toJson : Todo -> Value
-toJson todo =
+todo : Todo -> Value
+todo { label, isCompleted } =
     object
-        [ ("label", string todo.label)
-        , ("isCompleted", bool todo.isCompleted)
+        [ ("label", string label)
+        , ("isCompleted", bool isCompleted)
         ]
 
 
@@ -17,7 +17,14 @@ encode : Dict Int Todo -> String
 encode todoList =
     todoList
         |> Dict.toList
-        |> List.map
-            (Tuple.mapFirst toString << Tuple.mapSecond toJson)
-        |> object
+        |> List.map (tuple2 int todo)
+        |> list
         |> Json.Encode.encode 0
+
+
+tuple2 : (a -> Value) -> (b -> Value) -> ( a, b ) -> Value
+tuple2 leftEncoder rightEncoder ( left, right ) =
+    list 
+        [ leftEncoder left
+        , rightEncoder right
+        ]

--- a/src/TodoList/Encode.elm
+++ b/src/TodoList/Encode.elm
@@ -5,26 +5,26 @@ import Json.Encode exposing (Value, object, list, string, bool, int)
 import Dict exposing (Dict)
 
 
+encode : Dict Int Todo -> String
+encode todoList =
+    todoList
+        |> Dict.toList
+        |> List.map todoRow
+        |> list
+        |> Json.Encode.encode 0
+
+
+todoRow : ( Int, Todo ) -> Value
+todoRow ( key, value ) =
+    list 
+        [ int key
+        , todo value
+        ]
+
+
 todo : Todo -> Value
 todo { label, isCompleted } =
     object
         [ ("label", string label)
         , ("isCompleted", bool isCompleted)
-        ]
-
-
-encode : Dict Int Todo -> String
-encode todoList =
-    todoList
-        |> Dict.toList
-        |> List.map (tuple2 int todo)
-        |> list
-        |> Json.Encode.encode 0
-
-
-tuple2 : (a -> Value) -> (b -> Value) -> ( a, b ) -> Value
-tuple2 leftEncoder rightEncoder ( left, right ) =
-    list 
-        [ leftEncoder left
-        , rightEncoder right
         ]

--- a/src/TodoList/Encode.elm
+++ b/src/TodoList/Encode.elm
@@ -2,6 +2,7 @@ module TodoList.Encode exposing (encode)
 
 import TodoList.Data exposing (Todo)
 import Json.Encode exposing (Value, object, list, string, bool, int)
+import Dict exposing (Dict)
 
 
 toJson : Todo -> Value
@@ -9,13 +10,14 @@ toJson todo =
     object
         [ ("label", string todo.label)
         , ("isCompleted", bool todo.isCompleted)
-        , ("id", int todo.id)
         ]
 
 
-encode : List Todo -> String
+encode : Dict Int Todo -> String
 encode todoList =
     todoList
-        |> List.map toJson
-        |> list
+        |> Dict.toList
+        |> List.map
+            (Tuple.mapFirst toString << Tuple.mapSecond toJson)
+        |> object
         |> Json.Encode.encode 0

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -1,4 +1,6 @@
-module Utils exposing (onlyIf, mapIf)
+module Utils exposing (onlyIf, mapIf, identityInsert)
+
+import Dict exposing (Dict)
 
 
 onlyIf : Bool -> a -> Maybe a
@@ -18,3 +20,14 @@ mapIf p fn xs =
             x
     in
         List.map mapFn xs
+
+
+identityInsert : a -> Dict Int a -> Dict Int a
+identityInsert value dict =
+    let
+        maxId =
+            List.maximum (Dict.keys dict)
+                |> Maybe.withDefault 0
+
+    in
+        Dict.insert (maxId + 1) value dict

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -1,5 +1,4 @@
-module Utils exposing (onlyIf, mapIf, mapKeys, mapKeysOrFail)
-import Dict exposing (Dict)
+module Utils exposing (onlyIf, mapIf)
 
 
 onlyIf : Bool -> a -> Maybe a
@@ -19,50 +18,3 @@ mapIf p fn xs =
             x
     in
         List.map mapFn xs
-
-
-mapKeys :
-    (comparable1 -> comparable)
-    -> Dict comparable1 v -> Dict comparable v
-mapKeys fn dict =
-    dict
-        |> Dict.toList
-        |> List.map (Tuple.mapFirst fn)
-        |> Dict.fromList
-
-
-mapKeysOrFail :
-    (comparable1 -> Result err comparable)
-    -> Dict comparable1 v -> Result err (Dict comparable v)
-mapKeysOrFail fn dict =
-    dict
-        |> Dict.toList
-        |> List.map (mapFirstOrFail fn)
-        |> joinResults
-        |> Result.map Dict.fromList
-
-
-mapFirstOrFail :
-    (a -> Result err b)
-    -> ( a, c )
-    -> Result err ( b, c )
-mapFirstOrFail fn ( left, right ) =
-    case fn left of
-        Ok val ->
-            Ok ( val, right )
-        Err msg ->
-            Err msg
-
-
-joinResults : List (Result err value) -> Result err (List value)
-joinResults results =
-    case results of
-        [] ->
-            Ok []
-        result :: rest ->
-            case result of
-                Ok val ->
-                    joinResults rest
-                        |> Result.map ((::) val)
-                Err msg ->
-                    Err msg

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -1,4 +1,5 @@
-module Utils exposing (onlyIf, mapIf)
+module Utils exposing (onlyIf, mapIf, mapKeys, mapKeysOrFail)
+import Dict exposing (Dict)
 
 
 onlyIf : Bool -> a -> Maybe a
@@ -18,3 +19,50 @@ mapIf p fn xs =
             x
     in
         List.map mapFn xs
+
+
+mapKeys :
+    (comparable1 -> comparable)
+    -> Dict comparable1 v -> Dict comparable v
+mapKeys fn dict =
+    dict
+        |> Dict.toList
+        |> List.map (Tuple.mapFirst fn)
+        |> Dict.fromList
+
+
+mapKeysOrFail :
+    (comparable1 -> Result err comparable)
+    -> Dict comparable1 v -> Result err (Dict comparable v)
+mapKeysOrFail fn dict =
+    dict
+        |> Dict.toList
+        |> List.map (mapFirstOrFail fn)
+        |> joinResults
+        |> Result.map Dict.fromList
+
+
+mapFirstOrFail :
+    (a -> Result err b)
+    -> ( a, c )
+    -> Result err ( b, c )
+mapFirstOrFail fn ( left, right ) =
+    case fn left of
+        Ok val ->
+            Ok ( val, right )
+        Err msg ->
+            Err msg
+
+
+joinResults : List (Result err value) -> Result err (List value)
+joinResults results =
+    case results of
+        [] ->
+            Ok []
+        result :: rest ->
+            case result of
+                Ok val ->
+                    joinResults rest
+                        |> Result.map ((::) val)
+                Err msg ->
+                    Err msg


### PR DESCRIPTION
Refactor `model.todoList` to a `Dict Int Todo` to make duplicate ids impossible (#19).